### PR TITLE
Shopware 5.2 compatibility

### DIFF
--- a/Frontend/PaymPaymentCreditcard/Bootstrap.php
+++ b/Frontend/PaymPaymentCreditcard/Bootstrap.php
@@ -717,7 +717,7 @@ class Shopware_Plugins_Frontend_PaymPaymentCreditcard_Bootstrap extends Shopware
     private function _applyBackendViewModifications()
     {
         try {
-            $parent = $this->Menu()->findOneBy('label', 'logfile');
+            $parent = $this->Menu()->findOneBy(['label' => 'logfile']);
             $this->createMenuItem(array('label' => 'Paymill', 'class' => 'sprite-cards-stack', 'active' => 1,
                 'controller' => 'PaymillLogging', 'action' => 'index', 'parent' => $parent));
         } catch (Exception $exception) {


### PR DESCRIPTION
The plugin did not work with Shopware 5.2, because Shopware removed the possibility to use `$this->Menu()->findOneBy()` with two params instead of an array. Our fix works with all Shopware versions since Shopware 4.3, because `$this->Menu()` is a reference to the Doctrine repository of the Menu entity.